### PR TITLE
FIX: use https for accessing webapp submodule instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docker/webapp"]
 	path = docker/webapp
-	url = git@github.com:jambonz/jambonz-webapp.git
+	url = https://github.com/jambonz/jambonz-webapp.git


### PR DESCRIPTION
Just in case key has expired. May not be necessary but it means recursive cloning will hopefully not be interrupted.