### PR TITLE
Feature/add basic auth jaeger

### DIFF
--- a/cloudformation/jambonz-mini.yaml
+++ b/cloudformation/jambonz-mini.yaml
@@ -79,6 +79,14 @@ Parameters:
     Type: String
     Description: "(Optional) A DNS name that you will point to the jambonz webserver(s)"
     Default: ""
+  JaegerUsername:
+    Type: String
+    Description: "Basic Auth username for Jaeger"
+    Default: "admin"
+  JaegerPassword:
+    Type: String
+    Description: "Basic Auth password for Jaeger"
+    Default: "JambonzR0ck$"
 Conditions:
   ShouldEnableCloudWatch: !Equals
     - true
@@ -217,6 +225,10 @@ Resources:
                 sed -i -e "\@</head>@i\ $TAG" /home/admin/apps/jambonz-webapp/dist/index.html
 
                 # configure nginx for homer and grafana on the monitoring server
+              
+                #Add BasicAuth password for Jaeger
+                sudo htpasswd -b -c /etc/nginx/.htpasswd ${JaegerUsername} ${JaegerPassword}
+              
                 sudo cat << EOF > /etc/nginx/sites-available/default 
                 server {
                     listen 80;
@@ -273,6 +285,8 @@ Resources:
                     proxy_set_header Connection 'upgrade';
                     proxy_set_header Host \$host;
                     proxy_cache_bypass \$http_upgrade;
+                    auth_basic "Secured Endpoint";
+                    auth_basic_user_file /etc/nginx/.htpasswd;
                   }
                 }
               EOF
@@ -299,6 +313,8 @@ Resources:
             - URLPortal: !Ref URLPortal
               Cloudwatch: !Ref Cloudwatch
               CloudwatchLogRetention: !Ref CloudwatchLogRetention
+              JaegerUsername: !Ref JaegerUsername
+              JaegerPassword: !Ref JaegerPassword
 
   jambonzSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'

--- a/cloudformation/jambonz-scalable-production.yaml
+++ b/cloudformation/jambonz-scalable-production.yaml
@@ -266,6 +266,14 @@ Parameters:
     Type: String
     Description: "DNS name you will point to the jambonz webserver(s)"
     Default: "yourdomain.com"
+  JaegerUsername:
+    Type: String
+    Description: "Basic Auth username for Jaeger"
+    Default: "admin"
+  JaegerPassword:
+    Type: String
+    Description: "Basic Auth password for Jaeger"
+    Default: "JambonzR0ck$"
   StatsSampleRate: 
     Type: Number
     Description: sampling rate for metrics, a number between 0 and 1 inclusive
@@ -1819,6 +1827,10 @@ Resources:
               sudo systemctl restart telegraf
             
               # configure nginx for homer and grafana on the monitoring server
+              
+              #Add BasicAuth password for Jaeger
+              sudo htpasswd -b -c /etc/nginx/.htpasswd ${JaegerUsername} ${JaegerPassword}
+              
               sudo cat << EOF > /etc/nginx/sites-available/default 
               server {
                   listen 80;
@@ -1875,6 +1887,8 @@ Resources:
                   proxy_set_header Connection 'upgrade';
                   proxy_set_header Host \$host;
                   proxy_cache_bypass \$http_upgrade;
+                  auth_basic "Secured Endpoint";
+                  auth_basic_user_file /etc/nginx/.htpasswd;
                 }
               }
               EOF
@@ -1898,6 +1912,8 @@ Resources:
               JAMBONES_TIME_SERIES_HOST: !GetAtt MonitoringServerEC2.PrivateIp
               JWT_SECRET: !Ref EncryptionSecret
               URLPortal: !Ref URLPortal
+              JaegerUsername: !Ref JaegerUsername
+              JaegerPassword: !Ref JaegerPassword
               CloudwatchLogRetention: !Ref CloudwatchLogRetention
               DbCachingTTS: !Ref DbCachingTTS
 

--- a/cloudformation/jambonz-scalable-production.yaml
+++ b/cloudformation/jambonz-scalable-production.yaml
@@ -1009,7 +1009,6 @@ Resources:
                     JAMBONES_MYSQL_DATABASE: 'jambones',
                     JAMBONES_MYSQL_CONNECTION_LIMIT: 10,
                     JAMBONES_REDIS_HOST: '${JAMBONES_REDIS_HOST}',
-                    JAMBONES_REDIS_HOST: '${JAMBONES_REDIS_HOST}',
                     JAMBONES_REDIS_PORT: 6379,
                     JAMBONES_TIME_SERIES_HOST: '${JAMBONES_TIME_SERIES_HOST}',
                     ENABLE_METRICS: 1,

--- a/packer/jambonz-mini/scripts/install_nginx.sh
+++ b/packer/jambonz-mini/scripts/install_nginx.sh
@@ -4,6 +4,9 @@ echo "installing nginx"
 
 sudo apt-get install -y nginx
 
+echo "installing apache utils for htpasswd"
+sudo apt-get install -y apache2-utils
+
 cd /etc/nginx/sites-available
 sudo mv /tmp/nginx.default default
 

--- a/packer/jambonz-web-server/scripts/install_nginx.sh
+++ b/packer/jambonz-web-server/scripts/install_nginx.sh
@@ -5,7 +5,7 @@ echo "installing nginx"
 sudo apt-get install -y nginx
 
 echo "installing apache utils for htpasswd"
-sudo apt-get install apache2-utils
+sudo apt-get install -y apache2-utils
 
 sudo systemctl enable nginx
 sudo systemctl restart nginx

--- a/packer/jambonz-web-server/scripts/install_nginx.sh
+++ b/packer/jambonz-web-server/scripts/install_nginx.sh
@@ -4,6 +4,9 @@ echo "installing nginx"
 
 sudo apt-get install -y nginx
 
+echo "installing apache utils for htpasswd"
+sudo apt-get install apache2-utils
+
 sudo systemctl enable nginx
 sudo systemctl restart nginx
 


### PR DESCRIPTION
Vanilla install of Jaeger does not have any security which exposes log data of internal Jambonz cluster open to public.

Using nginx we can secure using basic auth.

Actions taken:

**Packer**
- install apache2-utils

**CloudFormation**
- create password hash using htpassword
- add basic_auth details to  /etc/nginx/sites-available/default
- removed duplicate JAMBONES_REDIS_HOST in ecosystem.config.js