### PR TITLE
added jaeger base url for querying by jambones-api-server

### DIFF
--- a/cloudformation/jambonz-scalable-production.yaml
+++ b/cloudformation/jambonz-scalable-production.yaml
@@ -1780,6 +1780,7 @@ Resources:
                     HOMER_BASE_URL: 'http://${MONITORING_SERVER_IP}:9080',
                     HOMER_USERNAME: 'admin',
                     HOMER_PASSWORD: 'sipcapture',
+                    JAEGER_BASE_URL: 'http://${MONITORING_SERVER_IP}:16686',
                     JWT_SECRET: '${JWT_SECRET}'
                     },
                 },


### PR DESCRIPTION
for jambones-api-server to query jaeger backend, its needs to know the ip and port of the jaeger server.

-Added JAEGER_BASE_URL to cloudformation script