### PR TITLE
Update docker-compose.yaml with ENCRYPTION_SECRET default

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -160,6 +160,7 @@ services:
       ENABLE_METRICS: 0
       JAMBONES_NETWORK_CIDR: 172.10.0.0/16
       JAMBONES_TIME_SERIES_HOST: 172.10.0.61
+      ENCRYPTION_SECRET: 'supersecret'
     depends_on:
       - mysql
       - redis
@@ -243,6 +244,7 @@ services:
       JAMBONES_FEATURE_SERVERS: 172.10.0.50:9022:cymru
       JAMBONES_FREESWITCH: 172.10.0.51:8021:ClueCon
       JAMBONES_TIME_SERIES_HOST: 172.10.0.61
+      ENCRYPTION_SECRET: 'supersecret'
     depends_on:
       - mysql
       - redis


### PR DESCRIPTION
If there is no `ENCRYPTION_SECRET` or `JWT_SECRET` variable set, you will get this error on the feature-server and sbc-inbound when running docker compose:

```
docker-feature-server-1  | node:internal/crypto/hash:109
docker-feature-server-1  |     throw new ERR_INVALID_ARG_TYPE(
docker-feature-server-1  |     ^
docker-feature-server-1  |
docker-feature-server-1  | TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received undefined
docker-feature-server-1  |     at new NodeError (node:internal/errors:399:5)
docker-feature-server-1  |     at Hash.update (node:internal/crypto/hash:109:11)
docker-feature-server-1  |     at Object.<anonymous> (/opt/app/lib/utils/encrypt-decrypt.js:6:4)
docker-feature-server-1  |     at Module._compile (node:internal/modules/cjs/loader:1254:14)
docker-feature-server-1  |     at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
docker-feature-server-1  |     at Module.load (node:internal/modules/cjs/loader:1117:32)
docker-feature-server-1  |     at Module._load (node:internal/modules/cjs/loader:958:12)
docker-feature-server-1  |     at Module.require (node:internal/modules/cjs/loader:1141:19)
docker-feature-server-1  |     at require (node:internal/modules/cjs/helpers:110:18)
docker-feature-server-1  |     at Object.<anonymous> (/opt/app/lib/utils/db-utils.js:1:19) {
docker-feature-server-1  |   code: 'ERR_INVALID_ARG_TYPE'
docker-feature-server-1  | }
docker-feature-server-1  |
docker-feature-server-1  | Node.js v18.15.0
docker-feature-server-1 exited with code 1
```