### PR TITLE
fix/packer/aws/jaeger

### DIFF
--- a/packer/jambonz-monitoring/aws/files/jaeger-collector.service
+++ b/packer/jambonz-monitoring/aws/files/jaeger-collector.service
@@ -6,6 +6,7 @@ After=network.target
 Environment="SPAN_STORAGE_TYPE=cassandra"
 Environment="CASSANDRA_SERVERS=127.0.0.1"
 Environment="CASSANDRA_KEYSPACE=jaeger_v1_dc1"
+ExecStartPre=/bin/sleep 60
 ExecStart=/usr/local/bin/jaeger-collector --cassandra.keyspace=jaeger_v1_dc1 --cassandra.servers=127.0.0.1 --cassandra.username=jaeger --cassandra.password=JambonzR0ck$ --collector.num-workers=50 --collector.queue-size=2000 --collector.http-server.host-port=0.0.0.0:14268
 User=admin
 Restart=on-failure

--- a/packer/jambonz-monitoring/aws/files/jaeger-query.service
+++ b/packer/jambonz-monitoring/aws/files/jaeger-query.service
@@ -6,6 +6,7 @@ After=network.target
 Environment="SPAN_STORAGE_TYPE=cassandra"
 Environment="CASSANDRA_SERVERS=127.0.0.1"
 Environment="CASSANDRA_KEYSPACE=jaeger_v1_dc1"
+ExecStartPre=/bin/sleep 60
 ExecStart=/usr/local/bin/jaeger-query --cassandra.keyspace=jaeger_v1_dc1 --cassandra.servers=127.0.0.1 --cassandra.username=jaeger --cassandra.password=JambonzR0ck$
 User=admin
 Restart=on-failure


### PR DESCRIPTION
Fix for AWS packer in regard to the jaeger services on the monitoring server. This will delay the start of the services for 60 seconds. If we do not delay the services they will fail to start on reboot.