### PR TITLE
Set default locale to en_US.UTF-8

### DIFF
--- a/packer/jambonz-feature-server/aws/scripts/install_os_tuning.sh
+++ b/packer/jambonz-feature-server/aws/scripts/install_os_tuning.sh
@@ -14,3 +14,12 @@ vm.dirty_writeback_centisecs=100
 EOT'
 
 sudo cp /tmp/20auto-upgrades /etc/apt/apt.conf.d/20auto-upgrades
+
+# Fix locales
+sudo bash -c 'cat >> /etc/default/locale << EOT
+LANG="en_US.UTF-8"
+LANGUAGE="en_US:en"
+EOT'
+
+sudo sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen
+sudo dpkg-reconfigure --frontend=noninteractive locales

--- a/packer/jambonz-mini/aws/scripts/install_os_tuning.sh
+++ b/packer/jambonz-mini/aws/scripts/install_os_tuning.sh
@@ -14,3 +14,12 @@ vm.dirty_writeback_centisecs=100
 EOT'
 
 sudo cp /tmp/20auto-upgrades /etc/apt/apt.conf.d/20auto-upgrades
+
+# Fix locales
+sudo bash -c 'cat >> /etc/default/locale << EOT
+LANG="en_US.UTF-8"
+LANGUAGE="en_US:en"
+EOT'
+
+sudo sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen
+sudo dpkg-reconfigure --frontend=noninteractive locales

--- a/packer/jambonz-monitoring/aws/scripts/install_os_tuning.sh
+++ b/packer/jambonz-monitoring/aws/scripts/install_os_tuning.sh
@@ -14,3 +14,12 @@ vm.dirty_writeback_centisecs=100
 EOT'
 
 sudo cp /tmp/20auto-upgrades /etc/apt/apt.conf.d/20auto-upgrades
+
+# Fix locales
+sudo bash -c 'cat >> /etc/default/locale << EOT
+LANG="en_US.UTF-8"
+LANGUAGE="en_US:en"
+EOT'
+
+sudo sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen
+sudo dpkg-reconfigure --frontend=noninteractive locales

--- a/packer/jambonz-sbc-rtp/aws/scripts/install_os_tuning.sh
+++ b/packer/jambonz-sbc-rtp/aws/scripts/install_os_tuning.sh
@@ -14,3 +14,12 @@ vm.dirty_writeback_centisecs=100
 EOT'
 
 sudo cp /tmp/20auto-upgrades /etc/apt/apt.conf.d/20auto-upgrades
+
+# Fix locales
+sudo bash -c 'cat >> /etc/default/locale << EOT
+LANG="en_US.UTF-8"
+LANGUAGE="en_US:en"
+EOT'
+
+sudo sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen
+sudo dpkg-reconfigure --frontend=noninteractive locales

--- a/packer/jambonz-sbc-sip-rtp/aws/scripts/install_os_tuning.sh
+++ b/packer/jambonz-sbc-sip-rtp/aws/scripts/install_os_tuning.sh
@@ -14,3 +14,12 @@ vm.dirty_writeback_centisecs=100
 EOT'
 
 sudo cp /tmp/20auto-upgrades /etc/apt/apt.conf.d/20auto-upgrades
+
+# Fix locales
+sudo bash -c 'cat >> /etc/default/locale << EOT
+LANG="en_US.UTF-8"
+LANGUAGE="en_US:en"
+EOT'
+
+sudo sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen
+sudo dpkg-reconfigure --frontend=noninteractive locales

--- a/packer/jambonz-sbc-sip/aws/scripts/install_os_tuning.sh
+++ b/packer/jambonz-sbc-sip/aws/scripts/install_os_tuning.sh
@@ -14,3 +14,12 @@ vm.dirty_writeback_centisecs=100
 EOT'
 
 sudo cp /tmp/20auto-upgrades /etc/apt/apt.conf.d/20auto-upgrades
+
+# Fix locales
+sudo bash -c 'cat >> /etc/default/locale << EOT
+LANG="en_US.UTF-8"
+LANGUAGE="en_US:en"
+EOT'
+
+sudo sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen
+sudo dpkg-reconfigure --frontend=noninteractive locales

--- a/packer/jambonz-web-server-and-monitoring-server/aws/scripts/install_os_tuning.sh
+++ b/packer/jambonz-web-server-and-monitoring-server/aws/scripts/install_os_tuning.sh
@@ -14,3 +14,12 @@ vm.dirty_writeback_centisecs=100
 EOT'
 
 sudo cp /tmp/20auto-upgrades /etc/apt/apt.conf.d/20auto-upgrades
+
+# Fix locales
+sudo bash -c 'cat >> /etc/default/locale << EOT
+LANG="en_US.UTF-8"
+LANGUAGE="en_US:en"
+EOT'
+
+sudo sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen
+sudo dpkg-reconfigure --frontend=noninteractive locales

--- a/packer/jambonz-web-server/aws/scripts/install_os_tuning.sh
+++ b/packer/jambonz-web-server/aws/scripts/install_os_tuning.sh
@@ -14,3 +14,12 @@ vm.dirty_writeback_centisecs=100
 EOT'
 
 sudo cp /tmp/20auto-upgrades /etc/apt/apt.conf.d/20auto-upgrades
+
+# Fix locales
+sudo bash -c 'cat >> /etc/default/locale << EOT
+LANG="en_US.UTF-8"
+LANGUAGE="en_US:en"
+EOT'
+
+sudo sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen
+sudo dpkg-reconfigure --frontend=noninteractive locales


### PR DESCRIPTION
This PR fixes the issue https://github.com/jambonz/jambonz-infrastructure/issues/63
It sets the default locale to `en_US.UTF-8` in all the packer images on aws.